### PR TITLE
Add flush before list collection

### DIFF
--- a/milvus_cli/utils.py
+++ b/milvus_cli/utils.py
@@ -118,9 +118,14 @@ class PyOrm(object):
             showindex=True,
         )
 
+    def flushCollectionByNumEntities(self, collectionName):
+        col = self.getTargetCollection(collectionName)
+        return col.num_entities
+
     def showCollectionLoadingProgress(self, collectionName, partition_names=None):
         from pymilvus import loading_progress
 
+        self.flushCollectionByNumEntities(collectionName)
         return loading_progress(collectionName, partition_names, self.alias)
 
     def showIndexBuildingProgress(self, collectionName, index_name=""):


### PR DESCRIPTION
Form User Success Team:
Customer insert data into a collection, then CLI `list collection` returns an incorrect entities number.

After investigation:
`list collection` use `loading_progress` which will not flush collection. If user insert data using other tools(like pymilvus, milvus-insight) instead of CLI, the issue may happen.

Solution:
Add flush before list collection.